### PR TITLE
installer: mime fixup

### DIFF
--- a/installer/kde/desktop.in
+++ b/installer/kde/desktop.in
@@ -2,7 +2,7 @@
 Type=Service
 Name=Valve Texture Format Files (${PROJECT_NAME_PRETTY})
 X-KDE-ServiceTypes=ThumbCreator
-MimeType=image/x-vtf;
+MimeType=image/x-vtf;image/vnd.valve.source.texture;
 X-KDE-Library=${PROJECT_NAME}
 CacheThumbnail=false
 ThumbnailerVersion=1

--- a/installer/kde/plugin.json.in
+++ b/installer/kde/plugin.json.in
@@ -1,8 +1,8 @@
 {
     "CacheThumbnail": false,
     "KPlugin": {
-        "MimeTypes": ["image/x-vtf"],
+        "MimeTypes": ["image/x-vtf", "image/vnd.valve.source.texture"],
         "Name": "Valve Texture Format Files (${PROJECT_NAME_PRETTY})"
     },
-    "MimeType": "image/x-vtf;"
+    "MimeType": "image/x-vtf;image/vnd.valve.source.texture;"
 }

--- a/installer/linux/mime-type.in
+++ b/installer/linux/mime-type.in
@@ -7,5 +7,8 @@
         <glob-deleteall/>
         <glob pattern="*.vtf"/>
         <glob pattern="*.VTF"/>
+        <magic priority="50">
+            <match value="VTF\0" type="string" offset="0"/>
+        </magic>
     </mime-type>
 </mime-info>

--- a/installer/linux/thumbnailer.in
+++ b/installer/linux/thumbnailer.in
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
 TryExec=/opt/${PROJECT_NAME}/${PROJECT_NAME}
 Exec=/opt/${PROJECT_NAME}/${PROJECT_NAME} -i %i -o %o -s %s
-MimeType=image/x-vtf;
+MimeType=image/x-vtf;image/vnd.valve.source.texture;


### PR DESCRIPTION
if users already have a mime type installed for vtf that's primarily `image/vnd.valve.source.texture` the system may refuse to acknowledge this as an acceptable thumbnailer, even if aliases are specified

(it's me i'm users)


